### PR TITLE
Dev

### DIFF
--- a/.github/workflows/wandb_workflow.yaml
+++ b/.github/workflows/wandb_workflow.yaml
@@ -1,5 +1,4 @@
 name: W&B Integration
-
 on:
     issue_comment: # tigger on pr comment
 

--- a/src/compare_logs.py
+++ b/src/compare_logs.py
@@ -28,10 +28,10 @@ def compare_runs(entity= "himasha" ,
     
     # get the entity / project / tag / run id from enviroment variables
     assert os.environ['WANDB_API_KEY'] , "You must set the wandb client api key !!!!"
-    ENTITY = os.getenv['ENTITY'] or entity
-    PROJECT = os.getenv['PROJECT'] or project
-    TAG =  os.getenv['TAG'] or tag
-    RUN_ID = os.getenv['RUN_ID'] or run_id
+    ENTITY = os.getenv('ENTITY') or entity
+    PROJECT = os.getenv('PROJECT') or project
+    TAG =  os.getenv('TAG') or tag
+    RUN_ID = os.getenv('RUN_ID') or run_id
 
     # get the baseline run
     run_init =  get_baseline_run(entity=ENTITY , 

--- a/src/model_register.py
+++ b/src/model_register.py
@@ -5,11 +5,11 @@ import wandb
 
 assert os.environ['WANDB_API_KEY'] , "You must set the wandb client api key !!!!"
 #define other first citizen params
-ENTITY = os.getenv['ENTITY'] or 'himasha'
-PROJECT = os.getenv['PROJECT'] or 'mnist-experiment'
-MODEL_TAG = os.getenv['WANDB_TAG'] or 'production-candidate'
-RUN_ID =  os.getenv['RUN_ID']
-MODEL_REGISTRY = os.getenv['REGISTRY'] or 'mnist-registry'
+ENTITY = os.getenv('ENTITY') or 'himasha'
+PROJECT = os.getenv('PROJECT') or 'mnist-experiment'
+MODEL_TAG = os.getenv('WANDB_TAG') or 'production-candidate'
+RUN_ID =  os.getenv('RUN_ID')
+MODEL_REGISTRY = os.getenv('REGISTRY') or 'mnist-registry'
 
 # init wandb client
 api = wandb.Api()


### PR DESCRIPTION
wandb integration with pr comment to trigger when pr comment having /wandb prefix followed by the experiment id , then automated comment will be generated with the wandb run comparison report related to baseline and model registry url